### PR TITLE
Add GRMR-V3 GGUF integration plan and smoke test harness

### DIFF
--- a/docs/GRMR_V3_GGUF_TEST_PLAN.md
+++ b/docs/GRMR_V3_GGUF_TEST_PLAN.md
@@ -1,0 +1,168 @@
+# GRMR-V3 Q4B GGUF Integration & Test Plan
+
+## Purpose
+
+Follow up on the October 2025 T5 evaluation by outlining how to integrate and
+validate the **GRMR-V3-Q4B.Q4_K_M.gguf** local model inside SATCN. The goal is to
+replicate the successful parts of the T5 experiment (clean architecture hooks,
+repeatable tests, rich logging) while accounting for the llama.cpp runtime that
+GGUF models require.
+
+## Model Assets
+
+| Item | Notes |
+| --- | --- |
+| Model file | `.GRMR-V3-Q4B-GGUF/GRMR-V3-Q4B.Q4_K_M.gguf` (quantized 4-bit) |
+| Runtime | [`llama-cpp-python`](https://github.com/abetlen/llama-cpp-python) bindings or native `llama.cpp` binary |
+| Context window | Plan around **4096 tokens** (confirm once model loads) |
+| Suggested precision | Keep Q4_K_M as-is; upgrading to Q5/Q6 later for quality comparison |
+| License | Confirm redistribution constraints before bundling |
+
+Store the model directory at the repository root (next to `flan-t5-large-grammar-synthesis/`).
+
+## Implementation Overview
+
+1. **Add runtime dependencies**
+   - Create a new optional requirements file (e.g. `requirements-grmr.txt`) listing:
+     - `llama-cpp-python>=0.2.90`
+     - `numpy>=1.24`
+     - `diskcache` (optional prompt caching)
+   - Document GPU build flags (e.g. `CMAKE_ARGS="-DLLAMA_CUBLAS=on" pip install llama-cpp-python`).
+
+2. **Wrap the GGUF model in a filter class**
+   - Add `pipeline/filters/grmr_v3_filter.py`.
+   - Mirror the public API of `pipeline.filters.t5_grammar_filter.T5GrammarFilter`:
+     - `__init__(model_path, device, max_new_tokens, temperature, top_p, repeat_penalty, logger)`
+     - `correct_text(text: str) -> str`
+     - `process(data: dict) -> dict`
+   - Use `llama_cpp.Llama` for inference. Suggested configuration:
+
+     ```python
+     from llama_cpp import Llama
+
+     class GRMRV3GrammarFilter:
+         DEFAULT_MODEL_PATH = Path('.GRMR-V3-Q4B-GGUF/GRMR-V3-Q4B.Q4_K_M.gguf')
+
+         def __init__(self, model_path=None, n_ctx=4096, max_new_tokens=256, temperature=0.1,
+                      top_p=0.15, repeat_penalty=1.05, device=None, logger=None):
+             ...
+             self.llm = Llama(
+                 model_path=str(Path(model_path or self.DEFAULT_MODEL_PATH)),
+                 n_ctx=n_ctx,
+                 n_gpu_layers=-1 if device == 'cuda' else 0,
+                 use_mlock=True,
+                 use_mmap=True,
+             )
+     ```
+
+   - Prompt template (revise after sampling outputs):
+
+     ```text
+     ### Instruction
+     You are a copy editor. Fix grammar, spelling, and punctuation while keeping
+     character names, slang, and factual content unchanged. Respond with the
+     corrected text only.
+
+     ### Input
+     {text}
+
+     ### Response
+     ```
+
+   - Enforce deterministic decoding for repeatability: `temperature=0.1`, `top_p=0.15`, `frequency_penalty=0.0`, `presence_penalty=0.0`.
+   - Track stats similar to `T5CorrectionFilter` (tokens generated, latency, edits made).
+
+3. **Pipeline wiring**
+   - Add a feature flag to `pipeline/pipeline_runner.py`:
+     - CLI option `--use-grmr` with modes (`replace`, `hybrid`, `supplement`), parallel to the T5 flags.
+     - Instantiate `GRMRV3GrammarFilter` when the flag is active.
+   - Expose the filter at the correction layer (e.g. in `satcn/correction/__init__.py`).
+   - Provide configuration knobs (model path, device) via environment variables or CLI arguments.
+
+4. **Logging and observability**
+   - Use per-block logging identical to `T5CorrectionFilter` statistics (`duration_ms`, `changes`).
+   - Emit warnings when:
+     - Context length would exceed `n_ctx` (truncate input with notice).
+     - Model path is missing.
+     - llama.cpp falls back to CPU.
+   - Optional: write generated tokens to `.cache/grmr_v3/` for debugging.
+
+5. **Documentation updates**
+   - Add a new section to `docs/T5_MODEL_GUIDE.md` summarizing the GGUF experiment.
+   - Create a quick-start doc describing how to build llama-cpp with GPU acceleration (Windows + Linux instructions).
+   - Update `README.md` with a short blurb and link to this plan.
+
+## Test Plan
+
+### Test Environment Matrix
+
+| Environment | Notes |
+| --- | --- |
+| **CUDA GPU** (preferred) | Verify `n_gpu_layers=-1` and ~2–3s per block latency |
+| **CPU only** | Expect ~20–40s per block; ensure graceful warnings |
+| **Apple Silicon (MPS)** | llama.cpp supports Metal; verify `GGML_METAL_PATH` instructions |
+
+### Automated Tests (PyTest)
+
+| Test ID | Type | Description |
+| --- | --- | --- |
+| `UT-GRMR-INIT` | Unit | Ensure `GRMRV3GrammarFilter` loads when model file exists; skip if llama-cpp unavailable |
+| `UT-GRMR-PROMPT` | Unit | Validate prompt builder preserves placeholders, forbids empty responses |
+| `UT-GRMR-CORRECT` | Unit | Feed a short faulty sentence, assert deterministic correction (baseline string stored in fixture) |
+| `UT-GRMR-PROCESS` | Unit | Mirror `tests/unit/test_t5_grammar_filter.py::test_process_pipeline_data` |
+| `UT-GRMR-DEVICE` | Unit | Force CPU/GPU selection, ensure config passed to llama.cpp |
+| `IT-GRMR-PIPELINE` | Integration | Run through `pipeline.runner` with `--use-grmr replace` on `tools/test_short.md` |
+| `IT-GRMR-HYBRID` | Integration | Run `--use-grmr hybrid` and assert both GGUF + rule-based filters fire |
+| `IT-GRMR-REGRESSION` | Regression | Diff corrected output for `tools/pipeline_test_text.md` against approved snapshot |
+| `PERF-GRMR-LATENCY` | Benchmark | Use `pytest-benchmark` to log time per block (compare to T5 results) |
+
+### Manual / Exploratory Tests
+
+1. **Smoke Script (`test_grmr_v3_integration.py`)**
+   - Mirrors `test_t5_integration.py`.
+   - Steps:
+     1. Verify that `GRMRV3GrammarFilter` can import.
+     2. Run standalone corrections over 5 canned sentences.
+     3. Run pipeline-style data to confirm block-level edits.
+     4. Print integration guide (installation commands, CLI usage).
+
+2. **Character-name preservation**
+   - Use `tests/samples/sample_story.md`; ensure protagonist names remain unchanged.
+   - Compare with T5 output to determine regressions.
+
+3. **Edge-case prompts**
+   - Very short text (`"ok"`), markdown lists, dialogue-heavy passages.
+   - Confirm model doesn't hallucinate formatting or add explanations.
+
+4. **Long context stress test**
+   - Feed `tools/pipeline_test_text.md` concatenated twice (~500+ tokens).
+   - Verify truncation warnings and stability.
+
+### Acceptance Criteria
+
+- Model initializes in < 15 seconds on GPU, < 60 seconds on CPU.
+- Average latency ≤ 5 seconds per 200-token block on GPU (benchmark target).
+- Corrections do not change more than 5% of tokens when input already clean.
+- Proper nouns identical between input and output for regression corpus (diff via `difflib`).
+- Zero critical exceptions across automated suite.
+
+## Risk & Mitigations
+
+| Risk | Mitigation |
+| --- | --- |
+| llama-cpp build complexity | Provide pre-built wheel instructions; include CPU-only fallback |
+| Determinism of sampling | Use low temperature & greedy decoding; add integration snapshot tests |
+| Memory pressure on low-end GPUs | Allow `n_gpu_layers` override and CPU fallback with warning |
+| Model quality unknown | Keep T5 as default, guard behind `--use-grmr` flag until validated |
+
+## Next Steps Checklist
+
+1. [ ] Install llama-cpp runtime and validate `llama_cpp` import.
+2. [ ] Implement `GRMRV3GrammarFilter` wrapper (see Implementation Overview).
+3. [ ] Add automated tests outlined above (unit + integration + regression).
+4. [ ] Fill out `test_grmr_v3_integration.py` expected outputs once model tuned.
+5. [ ] Run benchmark suite; compare against `docs/T5_TESTING_SESSION_OCT2025.md` metrics.
+6. [ ] Update documentation and announce experimental availability.
+
+Once these steps pass, schedule a follow-up evaluation session mirroring the
+structure used for the October 2025 T5 trial.

--- a/test_grmr_v3_integration.py
+++ b/test_grmr_v3_integration.py
@@ -1,0 +1,172 @@
+#!/usr/bin/env python3
+"""Manual integration harness for the GRMR-V3 GGUF grammar model.
+
+This mirrors ``test_t5_integration.py`` but targets the local
+`.GRMR-V3-Q4B-GGUF/GRMR-V3-Q4B.Q4_K_M.gguf` model via llama.cpp bindings.
+
+Usage (after implementing ``GRMRV3GrammarFilter``):
+
+    $ python test_grmr_v3_integration.py
+
+The script:
+    1. Verifies that the GGUF model file exists.
+    2. Loads ``GRMRV3GrammarFilter``.
+    3. Runs a standalone text correction demo.
+    4. Exercises pipeline-style input data.
+    5. Prints an integration checklist.
+
+Until the filter is implemented, the script will exit early with guidance.
+"""
+
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+from typing import List, Optional
+
+MODEL_PATH = Path('.GRMR-V3-Q4B-GGUF/GRMR-V3-Q4B.Q4_K_M.gguf')
+
+try:
+    from pipeline.filters.grmr_v3_filter import GRMRV3GrammarFilter  # type: ignore
+except ImportError:
+    GRMRV3GrammarFilter = None  # type: ignore
+
+
+def _print_header(title: str) -> None:
+    print("\n" + "=" * 60)
+    print(title)
+    print("=" * 60 + "\n")
+
+
+def _check_model_file() -> bool:
+    if MODEL_PATH.exists():
+        print(f"✓ Found model file at {MODEL_PATH}")
+        return True
+
+    print(f"❌ Model file not found at {MODEL_PATH}")
+    print("   Expected a local GGUF model. Download or move the file before running tests.")
+    return False
+
+
+def _ensure_filter_available() -> Optional[GRMRV3GrammarFilter]:  # type: ignore[name-defined]
+    if GRMRV3GrammarFilter is None:
+        print("❌ GRMRV3GrammarFilter is not available yet.")
+        print("   Implement pipeline.filters.grmr_v3_filter.GRMRV3GrammarFilter as outlined in docs/GRMR_V3_GGUF_TEST_PLAN.md")
+        return None
+
+    try:
+        return GRMRV3GrammarFilter(model_path=str(MODEL_PATH))
+    except FileNotFoundError:
+        print("❌ Could not load the GGUF model. Double-check MODEL_PATH.")
+    except Exception as exc:  # pragma: no cover - diagnostic output only
+        print(f"❌ Failed to initialize GRMRV3GrammarFilter: {exc}")
+        print("   Confirm llama-cpp-python is installed and compiled with the right backend.")
+    return None
+
+
+def _demo_sentences(filter_instance: GRMRV3GrammarFilter) -> None:  # type: ignore[name-defined]
+    _print_header("Standalone grammar corrections")
+    test_cases: List[str] = [
+        "Thiss sentnce have two speling errrors.",
+        "The crew was suppose to arrive yesteday evening.",
+        "Irina said she dont wanna go to the market no more.",
+        "Their going too fast for the narow bridge.",
+        "I has forgotten where I put the keys."  # Keep simple for deterministic output
+    ]
+
+    for idx, text in enumerate(test_cases, start=1):
+        print(f"Test {idx}:")
+        print(f"  Original : {text}")
+        corrected = filter_instance.correct_text(text)
+        print(f"  Corrected: {corrected}\n")
+
+
+def _demo_pipeline(filter_instance: GRMRV3GrammarFilter) -> None:  # type: ignore[name-defined]
+    _print_header("Pipeline-style integration test")
+    sample_data = {
+        'text_blocks': [
+            {
+                'content': 'This block is mostly fine.',
+                'metadata': {'type': 'paragraph'}
+            },
+            {
+                'content': 'This block contain a grammar mistake.',
+                'metadata': {'type': 'paragraph'}
+            },
+            {
+                'content': 'Ther are multiple speling misteaks and punctuation problems here',
+                'metadata': {'type': 'paragraph'}
+            }
+        ]
+    }
+
+    print("Input data:")
+    for i, block in enumerate(sample_data['text_blocks']):
+        print(f"  Block {i}: {block['content']}")
+
+    result = filter_instance.process(sample_data)
+
+    print("\nOutput data:")
+    for i, block in enumerate(result['text_blocks']):
+        print(f"  Block {i}: {block['content']}")
+
+
+def _print_guide() -> None:
+    _print_header("Integration Guide")
+    guide = """
+To integrate GRMRV3GrammarFilter into the SATCN pipeline:
+
+1. Install dependencies
+   ---------------------
+   # CPU only
+   pip install llama-cpp-python numpy
+
+   # NVIDIA GPU (requires CUDA toolkit)
+   CMAKE_ARGS="-DLLAMA_CUBLAS=on" pip install llama-cpp-python numpy
+
+2. Implement the filter wrapper
+   -----------------------------
+   - File: pipeline/filters/grmr_v3_filter.py
+   - Class: GRMRV3GrammarFilter
+   - Follow docs/GRMR_V3_GGUF_TEST_PLAN.md for prompt + decoding settings
+
+3. Wire into the pipeline
+   ----------------------
+   - Update pipeline/pipeline_runner.py
+     * Add `--use-grmr` CLI switch mirroring `--use-t5`
+     * Instantiate GRMRV3GrammarFilter with the desired mode (replace/hybrid/supplement)
+   - Optionally expose via satcn/correction for programmatic use
+
+4. Run automated tests
+   --------------------
+   pytest tests/unit/test_grmr_v3_filter.py -k "not benchmark"
+   pytest tests/integration/test_grmr_v3_pipeline.py
+
+5. Compare against T5 baseline
+   ----------------------------
+   - Run docs/T5_TESTING_SESSION_OCT2025.md scenarios using both filters
+   - Capture latency + quality notes in docs/GRMR_V3_GGUF_TEST_PLAN.md
+"""
+    print(guide)
+
+
+def main() -> int:
+    _print_header("GRMR-V3 GGUF Grammar Model - Integration Test")
+
+    if not _check_model_file():
+        return 1
+
+    filter_instance = _ensure_filter_available()
+    if filter_instance is None:
+        return 1
+
+    _demo_sentences(filter_instance)
+    _demo_pipeline(filter_instance)
+    _print_guide()
+
+    print("\n✓ GRMR-V3 integration smoke test completed.")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())


### PR DESCRIPTION
## Summary
- document the planned steps for integrating the GRMR-V3-Q4B GGUF grammar model, including dependencies, pipeline wiring, and validation criteria
- add a manual integration script skeleton that mirrors the existing T5 harness and guides future testing once the filter wrapper is implemented

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_e_690430acf6c8832cbf7081d6a148b386